### PR TITLE
fix: uninitialized constant `Tap::TAP_DIRECTORY`

### DIFF
--- a/lib/toolchain.rb
+++ b/lib/toolchain.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-TAP_PATH = (Tap::TAP_DIRECTORY/"MaterializeInc"/"homebrew-crosstools").freeze
+TAP_DIR = HOMEBREW_TAP_DIRECTORY || Tap::TAP_DIRECTORY
+TAP_PATH = (TAP_DIR/"MaterializeInc"/"homebrew-crosstools").freeze
 
 class Toolchain < Formula
   desc "Appease RuboCop; not used"

--- a/lib/toolchain.rb
+++ b/lib/toolchain.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-TAP_DIR = HOMEBREW_TAP_DIRECTORY || Tap::TAP_DIRECTORY
-TAP_PATH = (TAP_DIR/"MaterializeInc"/"homebrew-crosstools").freeze
+TAP_PATH = (HOMEBREW_TAP_DIRECTORY/"MaterializeInc"/"homebrew-crosstools").freeze
 
 class Toolchain < Formula
   desc "Appease RuboCop; not used"


### PR DESCRIPTION
It looks like `Tap::TAP_DIRECTORY` was replaced in favor of `HOMEBREW_TAP_DIRECTORY` in https://github.com/Homebrew/brew/pull/18010, now when trying to install a package from this tap I get the following error:

```
materializeinc/crosstools/x86_64-unknown-linux-gnu: uninitialized constant Tap::TAP_DIRECTORY
materializeinc/crosstools/aarch64-unknown-linux-gnu: uninitialized constant Tap::TAP_DIRECTORY
```

I don't know Ruby very well but I think this change should work