### PR TITLE
troubleshooting brew doctor failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,8 @@ jobs:
       
       - run: git status .
 
-      - run: git status /usr/local/Homebrew
+      - run: git status .
+        working-directory: /usr/local/Homebrew
 
       - run: brew test-bot --only-setup -d
 


### PR DESCRIPTION
starting with macos 13 runners