### PR TITLE
fix: Get formula building again in GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
@@ -32,4 +32,4 @@ jobs:
         if: github.event.pull_request.head.repo.fork == false
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: git push --delete origin $BRANCH
+        run: git push --delete origin "$BRANCH"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,13 +49,13 @@ jobs:
 
       # 2. Cleanup the cloned homebrew-core repo to remove openssl@1.1 formulae.
       - name: Uninstall openssl@1.1
-        run: brew uninstall openssl@1.1 ; brew cleanup
+        run: brew uninstall openssl@1.1 || true ; brew cleanup
 
       # END OpenSSL v1.1 cleanup.
 
       # We also need to cleanup ruby@3.0 which `brew doctor` also complains about.
       - name: Uninstall ruby@3.0
-        run: brew uninstall ruby@3.0 ; brew cleanup
+        run: brew uninstall ruby@3.0 || true ; brew cleanup
 
       - name: Install Homebrew Bundler RubyGems
         run: brew install-bundler-gems

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,47 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-aarch64, macos-x86_64]
+        # x86_64 and aarch64 respectively.
+        os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+
+      # OpenSSL v1.1 is deprecated, and `brew doctor` complains about it in two
+      # different ways:
+      #
+      # 1. Some part of the `set-up-homebrew` action modifies the openssl1.1
+      #    Formula in the install homebrew-core repository that gets cloned and
+      #    then `brew doctor` complains about a non-clean repository.
+      # 2. Either as part of the default runner image, or again the
+      #    `set-up-homebrew` action, openssl@1.1 gets installed which is
+      #    deprecated and thus must also be uninstalled.
+
+      # 1. Cleanup the cloned homebrew-core repo to remove openssl@1.1 formulae.
+      - name: Get Homebrew Repo
+        run: |
+          MY_HOMEBREW_CORE_REPO="$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+          echo "MY_HOMEBREW_CORE_REPO=$MY_HOMEBREW_CORE_REPO" >> "$GITHUB_ENV"
+
+      - name: Check Homebrew Repo
+        run: git status .
+        working-directory: ${{ env.MY_HOMEBREW_CORE_REPO }}
+
+      - name: Clean Homebrew Repo
+        run: git restore . ; git clean -fd
+        working-directory: ${{ env.MY_HOMEBREW_CORE_REPO }}
+
+      - name: Check Homebrew Repo - Post Clean
+        run: git status .
+        working-directory: ${{ env.MY_HOMEBREW_CORE_REPO }}
+
+      # 2. Cleanup the cloned homebrew-core repo to remove openssl@1.1 formulae.
+      - name: Uninstall openssl@1.1
+        run: brew uninstall openssl@1.1 ; brew cleanup
+
+      # END OpenSSL v1.1 cleanup.
 
       - name: Install Homebrew Bundler RubyGems
         run: brew install-bundler-gems
@@ -25,7 +60,7 @@ jobs:
       # by looking for formulas with three dashes is gross, but works.
       - run: brew ls --formula | grep -- '-.*-.*-.*' | xargs brew uninstall -f
 
-      - run: brew test-bot --only-setup
+      - run: brew test-bot --verbose --only-setup
 
       - run: brew test-bot --only-tap-syntax
 
@@ -40,4 +75,4 @@ jobs:
         uses: actions/upload-artifact@main
         with:
           name: bottles
-          path: '*.bottle.*'
+          path: "*.bottle.*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,10 @@ jobs:
 
       # END OpenSSL v1.1 cleanup.
 
+      # We also need to cleanup ruby@3.0 which `brew doctor` also complains about.
+      - name: Uninstall ruby@3.0
+        run: brew uninstall ruby@3.0 ; brew cleanup
+
       - name: Install Homebrew Bundler RubyGems
         run: brew install-bundler-gems
 

--- a/lib/toolchain.rb
+++ b/lib/toolchain.rb
@@ -47,9 +47,20 @@ class Toolchain < Formula
   delegate linux_version: :"self.class"
 
   class << self
-    attr_rw :defconfig
-    attr_rw :glibc_version
-    attr_rw :linux_version
+    sig { params(val: String).returns(T.nilable(String)) }
+    def defconfig(val = T.unsafe(nil))
+      val.nil? ? @defconfig : @defconfig= T.let(val, T.nilable(String))
+    end
+
+    sig { params(val: String).returns(T.nilable(String)) }
+    def glibc_version(val = T.unsafe(nil))
+      val.nil? ? @glibc_version : @glibc_version= T.let(val, T.nilable(String))
+    end
+
+    sig { params(val: String).returns(T.nilable(String)) }
+    def linux_version(val = T.unsafe(nil))
+      val.nil? ? @linux_version : @linux_version= T.let(val, T.nilable(String))
+    end
 
     def inherited(formula)
       super


### PR DESCRIPTION
This PR gets the formulae building again a few changes were needed:

1. Remove the use of `attr_rw` which is no longer available (pulled from https://github.com/MaterializeInc/homebrew-crosstools/pull/12)
2. Remove all references to `openssl@1.1` which `brew doctor` kept complaining about
3. Uninstall `ruby@3.0` if it's present
4. Fix some spellcheck lints