### PR TITLE
Restore x86_64 toolchain, bump to 0.2.1

### DIFF
--- a/Formula/x86_64-unknown-linux-gnu.rb
+++ b/Formula/x86_64-unknown-linux-gnu.rb
@@ -2,17 +2,17 @@
 
 require_relative "../lib/toolchain"
 
-class Aarch64UnknownLinuxGnu < Toolchain
-  desc "aarch64 Linux GNU toolchain"
+class X8664UnknownLinuxGnu < Toolchain
+  desc "x86_64 Linux GNU toolchain"
   version "0.2.1"
 
   defconfig <<~EOS
-    CT_ARCH_ARM=y
+    CT_ARCH_X86=y
     CT_ARCH_64=y
   EOS
 
   def test_signature(sig)
-    assert_match "ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV)", sig
+    assert_match "ELF 64-bit LSB executable, x86-64, version 1 (SYSV)", sig
     assert_match "GNU/Linux 5.10.240", sig
   end
 end

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ brew install MaterializeInc/crosstools/<toolchain>
 Target                        | Binutils | GCC     | Kernel   | Glibc
 ------------------------------|----------|---------|----------|-------
 [`aarch64-unknown-linux-gnu`] | 2.45     | 15.2.0  | 5.10.240 | 2.35
+[`x86_64-unknown-linux-gnu`]  | 2.45     | 15.2.0  | 5.10.240 | 2.35
 
 
 ## Contributing
@@ -26,5 +27,6 @@ PRs that add additional toolchains are encouraged! Use one of the existing
 toolchain files as a guide.
 
 [`aarch64-unknown-linux-gnu`]: Formula/aarch64-unknown-linux-gnu.rb
+[`x86_64-unknown-linux-gnu`]: Formula/x86_64-unknown-linux-gnu.rb
 [Homebrew]: https://brew.sh
 [SergioBenitez/homebrew-osxct]: https://github.com/SergioBenitez/homebrew-osxct

--- a/lib/toolchain.rb
+++ b/lib/toolchain.rb
@@ -10,8 +10,6 @@ class Toolchain < Formula
     <%= defconfig %>
     CT_ALLOW_BUILD_AS_ROOT=y
     CT_ALLOW_BUILD_AS_ROOT_SURE=y
-    CT_ARCH_ARM=y
-    CT_ARCH_64=y
     CT_BINUTILS_LINKER_LD_GOLD=y
     CT_BINUTILS_GOLD_THREADS=y
     CT_BINUTILS_LD_WRAPPER=y
@@ -38,7 +36,6 @@ class Toolchain < Formula
     CT_LOG_TO_FILE=y
     # CT_LOG_FILE_COMPRESS is not set
     CT_NCURSES_PATCH_LOCAL=y
-    CT_PARALLEL_JOBS=1
     CT_PATCH_ORDER="bundled,local"
     CT_PATCH_BUNDLED_LOCAL=y
     CT_PATCH_USE_LOCAL=y

--- a/lib/toolchain.rb
+++ b/lib/toolchain.rb
@@ -80,31 +80,31 @@ class Toolchain < Formula
 
       resource "binutils" do
         url "https://mirror.team-cymru.com/gnu/binutils/binutils-2.45.tar.xz"
-        mirror "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.xz"
+        mirror "https://mirrors.kernel.org/gnu/binutils/binutils-2.45.tar.xz"
         sha256 "c50c0e7f9cb188980e2cc97e4537626b1672441815587f1eab69d2a1bfbef5d2"
       end
 
       resource "gcc" do
         url "https://mirror.team-cymru.com/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
-        mirror "https://ftpmirror.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+        mirror "https://mirrors.kernel.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
         sha256 "438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e"
       end
 
       resource "gettext" do
         url "https://mirror.team-cymru.com/gnu/gettext/gettext-0.26.tar.xz"
-        mirror "https://ftpmirror.gnu.org/gettext/gettext-0.26.tar.xz"
+        mirror "https://mirrors.kernel.org/gnu/gettext/gettext-0.26.tar.xz"
         sha256 "d1fb86e260cfe7da6031f94d2e44c0da55903dbae0a2fa0fae78c91ae1b56f00"
       end
 
       resource "glibc" do
         url "https://mirror.team-cymru.com/gnu/glibc/glibc-2.35.tar.xz"
-        mirror "https://ftpmirror.gnu.org/glibc/glibc-2.35.tar.xz"
+        mirror "https://mirrors.kernel.org/gnu/glibc/glibc-2.35.tar.xz"
         sha256 "5123732f6b67ccd319305efd399971d58592122bcc2a6518a1bd2510dd0cf52e"
       end
 
       resource "gmp" do
         url "https://mirror.team-cymru.com/gnu/gmp/gmp-6.3.0.tar.xz"
-        mirror "https://ftpmirror.gnu.org/gmp/gmp-6.3.0.tar.xz"
+        mirror "https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz"
         sha256 "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
       end
 
@@ -115,7 +115,7 @@ class Toolchain < Formula
 
       resource "libiconv" do
         url "https://mirror.team-cymru.com/gnu/libiconv/libiconv-1.18.tar.gz"
-        mirror "https://ftpmirror.gnu.org/libiconv/libiconv-1.18.tar.gz"
+        mirror "https://mirrors.kernel.org/gnu/libiconv/libiconv-1.18.tar.gz"
         sha256 "3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8"
       end
 

--- a/lib/toolchain.rb
+++ b/lib/toolchain.rb
@@ -79,32 +79,32 @@ class Toolchain < Formula
       depends_on "zstd"
 
       resource "binutils" do
-        url "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.xz"
-        mirror "https://ftp.gnu.org/pub/gnu/binutils/binutils-2.45.tar.xz"
+        url "https://mirror.team-cymru.com/gnu/binutils/binutils-2.45.tar.xz"
+        mirror "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.xz"
         sha256 "c50c0e7f9cb188980e2cc97e4537626b1672441815587f1eab69d2a1bfbef5d2"
       end
 
       resource "gcc" do
-        url "https://ftpmirror.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
-        mirror "https://ftp.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+        url "https://mirror.team-cymru.com/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+        mirror "https://ftpmirror.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
         sha256 "438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e"
       end
 
       resource "gettext" do
-        url "https://ftpmirror.gnu.org/gettext/gettext-0.26.tar.xz"
-        mirror "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.26.tar.xz"
+        url "https://mirror.team-cymru.com/gnu/gettext/gettext-0.26.tar.xz"
+        mirror "https://ftpmirror.gnu.org/gettext/gettext-0.26.tar.xz"
         sha256 "d1fb86e260cfe7da6031f94d2e44c0da55903dbae0a2fa0fae78c91ae1b56f00"
       end
 
       resource "glibc" do
-        url "https://ftpmirror.gnu.org/glibc/glibc-2.35.tar.xz"
-        mirror "https://ftp.gnu.org/pub/gnu/glibc/glibc-2.35.tar.xz"
+        url "https://mirror.team-cymru.com/gnu/glibc/glibc-2.35.tar.xz"
+        mirror "https://ftpmirror.gnu.org/glibc/glibc-2.35.tar.xz"
         sha256 "5123732f6b67ccd319305efd399971d58592122bcc2a6518a1bd2510dd0cf52e"
       end
 
       resource "gmp" do
-        url "https://ftpmirror.gnu.org/gmp/gmp-6.3.0.tar.xz"
-        mirror "https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz"
+        url "https://mirror.team-cymru.com/gnu/gmp/gmp-6.3.0.tar.xz"
+        mirror "https://ftpmirror.gnu.org/gmp/gmp-6.3.0.tar.xz"
         sha256 "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
       end
 
@@ -114,8 +114,8 @@ class Toolchain < Formula
       end
 
       resource "libiconv" do
-        url "https://ftpmirror.gnu.org/libiconv/libiconv-1.18.tar.gz"
-        mirror "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.18.tar.gz"
+        url "https://mirror.team-cymru.com/gnu/libiconv/libiconv-1.18.tar.gz"
+        mirror "https://ftpmirror.gnu.org/libiconv/libiconv-1.18.tar.gz"
         sha256 "3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8"
       end
 

--- a/lib/toolchain.rb
+++ b/lib/toolchain.rb
@@ -105,7 +105,6 @@ class Toolchain < Formula
       resource "gmp" do
         url "https://ftpmirror.gnu.org/gmp/gmp-6.3.0.tar.xz"
         mirror "https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz"
-        mirror "https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz"
         sha256 "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
       end
 


### PR DESCRIPTION
## Summary
- Re-add `x86_64-unknown-linux-gnu` formula that was dropped in 0.2.0
- Move arch-specific `CT_ARCH_*` settings from shared DEFCONFIG into each formula's `defconfig` block
- Bump both formulas to version 0.2.1

## Test plan
- [ ] CI builds both aarch64 and x86_64 toolchains
- [ ] Both `brew test` assertions pass (ELF signatures)
- [ ] `brew install` works for both formulas after pr-pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)